### PR TITLE
use simple-runtypes 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@
 
 ```
 io-ts:
-  411 687 ops/s, ±3.41%     | 65.23% slower
+  473 114 ops/s, ±1.77%     | 68.96% slower
 
 io-ts incorrect:
-  337 105 ops/s, ±2.82%     | 71.53% slower
+  375 343 ops/s, ±2.32%     | slowest, 75.37% slower
 
 simple-runtypes:
-  1 184 016 ops/s, ±3.22%   | fastest
+  1 524 091 ops/s, ±3.48%   | fastest
 
 simple-runtypes incorrect:
-  4 202 ops/s, ±5.81%       | slowest, 99.65% slower
+  1 021 229 ops/s, ±1.75%   | 32.99% slower
 ```
 
-![chart](https://user-images.githubusercontent.com/142528/97901834-c1709400-1d4d-11eb-8066-09f72aad211d.png)
+![chart](https://user-images.githubusercontent.com/142528/98253135-b86d0600-1f8b-11eb-82e7-bdefda0d29ed.png)

--- a/benchmark/results/result.chart.html
+++ b/benchmark/results/result.chart.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     <div style="max-width: 800px;">
-      <canvas id="chart1604339072649" width="16" height="9"></canvas>
+      <canvas id="chart1604585383315" width="16" height="9"></canvas>
     </div>
     <script>
       const format = num => {
@@ -34,10 +34,10 @@
 
         return chunked.map(chunk => chunk.join("")).join(" ");
       };
-      const ctx1604339072649 = document
-        .getElementById("chart1604339072649")
+      const ctx1604585383315 = document
+        .getElementById("chart1604585383315")
         .getContext("2d");
-      const chart1604339072649 = new Chart(ctx1604339072649, {
+      const chart1604585383315 = new Chart(ctx1604585383315, {
         type: "bar",
         data: {
           labels: [
@@ -48,7 +48,7 @@
           ],
           datasets: [
             {
-              data: [411687, 337105, 1184016, 4202],
+              data: [473114, 375343, 1524091, 1021229],
               backgroundColor: [
                 "rgba(63, 142, 252, 0.8)",
                 "rgba(116, 165, 127, 0.8)",

--- a/benchmark/results/result.json
+++ b/benchmark/results/result.json
@@ -1,31 +1,31 @@
 {
   "name": "vals",
-  "date": "2020-11-02T17:44:32.649Z",
+  "date": "2020-11-05T14:09:43.315Z",
   "version": "1.0.0",
   "results": [
     {
       "name": "io-ts",
-      "ops": 411687,
-      "margin": 3.41,
-      "percentSlower": 65.23
+      "ops": 473114,
+      "margin": 1.77,
+      "percentSlower": 68.96
     },
     {
       "name": "io-ts incorrect",
-      "ops": 337105,
-      "margin": 2.82,
-      "percentSlower": 71.53
+      "ops": 375343,
+      "margin": 2.32,
+      "percentSlower": 75.37
     },
     {
       "name": "simple-runtypes",
-      "ops": 1184016,
-      "margin": 3.22,
+      "ops": 1524091,
+      "margin": 3.48,
       "percentSlower": 0
     },
     {
       "name": "simple-runtypes incorrect",
-      "ops": 4202,
-      "margin": 5.81,
-      "percentSlower": 99.65
+      "ops": 1021229,
+      "margin": 1.75,
+      "percentSlower": 32.99
     }
   ],
   "fastest": {
@@ -33,7 +33,7 @@
     "index": 2
   },
   "slowest": {
-    "name": "simple-runtypes incorrect",
-    "index": 3
+    "name": "io-ts incorrect",
+    "index": 1
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -27,12 +27,5 @@ export function makeSR(): ValidatorFn {
   });
   // type Message = ReturnType<typeof messageST>;
 
-  return (msg) => {
-    try {
-      messageST(msg);
-      return true;
-    } catch {
-      return false;
-    }
-  };
+  return (msg) => st.use(messageST, msg).ok;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3797,9 +3797,9 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-runtypes": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/simple-runtypes/-/simple-runtypes-5.0.2.tgz",
-      "integrity": "sha512-K/7bYyBv35ZcnZIBIIq8Qa9mOaOws/B/KYukf3+0pFyMjGmpLE9LqQwnZTJyZHKg6r100fiO6Eyj5ITbp8PAvw=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/simple-runtypes/-/simple-runtypes-6.0.1.tgz",
+      "integrity": "sha512-Z1AZ9M0iyBf+tcCagRoIe6dgrg/PmRG3gw0+NRlQHJKmubmObccjcZg0o8cY/wsat37Wkv8MWhhORsEN9ZVVaQ=="
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "io-ts": "^2.2.12",
     "jest": "^26.6.2",
     "prettier": "^2.1.2",
-    "simple-runtypes": "^5.0.2",
+    "simple-runtypes": "^6.0.1",
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5"


### PR DESCRIPTION
It contains a more efficient API for using runtypes without exceptions. See also https://github.com/hoeck/simple-runtypes/issues/11